### PR TITLE
Replace scipy/numpy powered dom_color.in with average color function.

### DIFF
--- a/src/dom_color.in
+++ b/src/dom_color.in
@@ -1,33 +1,30 @@
 #!/usr/bin/env python3
-""" Calculate the dominant color of an image
+""" Calculate the average color of an image
 
-    Code obtained from: https://stackoverflow.com/questions/34084142/python-3-most-common-color-in-image-kmeans-data-type-match
+    Code adapted from from: https://github.com/ZeevG/python-dominant-image-colour
 """
 
+import binascii
+
 try:
-    import Image
+    import Image, ImageDraw
 except ImportError:
-    from PIL import Image
-import scipy.misc
-import scipy.cluster
-
-NUM_CLUSTERS = 5
-
+    from PIL import Image, ImageDraw
 
 def get_dom_color(filename):
-    im = Image.open(filename)
-    im = im.resize((150, 150))      # optional, to reduce time
-    ar = scipy.misc.fromimage(im)
-    shape = ar.shape
-    ar = ar.reshape(scipy.product(shape[:2]), shape[2])
+    image = Image.open(filename)
+    image = image.resize((150, 150))      # optional, to reduce time
 
-    codes, dist = scipy.cluster.vq.kmeans(ar.astype(float), NUM_CLUSTERS)
+    colour_tuple = [None, None, None]
+    for channel in range(3):
+        # Get data for one channel at a time
+        pixels = image.getdata(band=channel)
 
-    vecs, dist = scipy.cluster.vq.vq(ar, codes)         # assign codes
-    counts, bins = scipy.histogram(vecs, len(codes))    # count occurrences
+        values = []
+        for pixel in pixels:
+            values.append(pixel)
 
-    index_max = scipy.argmax(counts)                    # find most frequent
-    peak = codes[index_max]
-    peak = peak.astype(int)
-    colour = ''.join(format(c, '02x') for c in peak)
+        colour_tuple[channel] = int(sum(values) / len(values))
+
+    colour = binascii.hexlify(struct.pack('BBB', *colour_tuple)).decode('utf-8')
     return colour


### PR DESCRIPTION
Numpy and Scipy depend on most of the GCC tool chain in Debian and Ubuntu. Shipping `mate-dock-applet` in the Ubuntu MATE ISO image increases the ISO imges size by ~ 150MB as a result.

This pull requests modified the function `get_dom_color()` in `dom_color.in` with a function that computes the average colour of an image using just PIL or Pillow. While it produces slightly different results, please considered including this to help keep the Ubuntu MATE image a more reasonable size :-)