### PR TITLE
Make sure the event state exists before using it in GlobalKeyBinding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ Makefile
 Makefile.in
 missing
 py-compile
-
+aclocal.m4
+config.log
+config.status
+install-sh
+src/org.mate.panel.*

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ config.log
 config.status
 install-sh
 src/org.mate.panel.*
+.vscode

--- a/src/dock.in
+++ b/src/dock.in
@@ -2179,7 +2179,7 @@ class Dock(object):
             # state that .desktop filenames should not contain spaces, so....
             dfname = self.ccl_win.name.replace(" ", "-")
 
-            local_apps = os.path.expanduser("~/.local/share/appplications")
+            local_apps = os.path.expanduser("~/.local/share/applications")
             if not os.path.exists(local_apps):
                 # ~/.local/share/applications doesn't exist, so create it
                 os.mkdir(local_apps)

--- a/src/dock_applet.in
+++ b/src/dock_applet.in
@@ -739,15 +739,16 @@ class GlobalKeyBinding(GObject.GObject, threading.Thread):
         self.running = True
         while self.running:
             event = self.display.next_event()
-            modifiers = event.state & self.known_modifiers_mask
-            self.current_shortcut = None
-            if event.type == X.KeyPress and [event.detail, modifiers] in self.shortcuts:
-                # Track this shortcut to know which app to activate
-                self.current_shortcut = [event.detail, modifiers]
-                GLib.idle_add(self.idle)
-                self.display.allow_events(X.AsyncKeyboard, event.time)
-            else:
-                self.display.allow_events(X.ReplayKeyboard, event.time)
+            if (hasattr(event, 'state')):
+                modifiers = event.state & self.known_modifiers_mask
+                self.current_shortcut = None
+                if event.type == X.KeyPress and [event.detail, modifiers] in self.shortcuts:
+                    # Track this shortcut to know which app to activate
+                    self.current_shortcut = [event.detail, modifiers]
+                    GLib.idle_add(self.idle)
+                    self.display.allow_events(X.AsyncKeyboard, event.time)
+                else:
+                    self.display.allow_events(X.ReplayKeyboard, event.time)
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
Make sure the event state exists before using it. This is to solve launchpad bug #1767451.

https://bugs.launchpad.net/ubuntu/+source/mate-dock-applet/+bug/1767451