### PR TITLE
Fix icon rendering on HiDPI displays

### DIFF
--- a/src/dock.in
+++ b/src/dock.in
@@ -3150,10 +3150,7 @@ class Dock(object):
             stock_size = Gtk.IconSize.BUTTON
 
         dock_app.icon_filename = None
-
-        # TODO : this needs to be tested 
-        # Potential, but untested  fix for issue #144 - blurry app icons on HiDpi Monitors
-        icon_size = icon_size * self.box.get_scale_factor()
+        scale_factor = self.box.get_scale_factor()
 
         if dock_app.icon_name is None:
             # can happen e.g. with dock prefs window...
@@ -3166,11 +3163,12 @@ class Dock(object):
             dai = Gio.DesktopAppInfo.new_from_filename(dock_app.desktop_file)
             the_icon = dai.get_icon()
             if the_icon is Gio.ThemedIcon:
-                icon_info = self.icontheme.choose_icon(the_icon.get_names(), icon_size, 0)
+                icon_info = self.icontheme.choose_icon_for_scale(the_icon.get_names(),
+                                                                 icon_size, scale_factor, 0)
             else:
-                icon_info = self.icontheme.choose_icon([dock_app.icon_name, None],
-                                                       icon_size, 0)
-#
+                icon_info = self.icontheme.choose_icon_for_scale([dock_app.icon_name, None],
+                                                                 icon_size, scale_factor, 0)
+
             if icon_info is not None:
                 dock_app.icon_filename = icon_info.get_filename()
                 try:
@@ -3181,9 +3179,6 @@ class Dock(object):
                                                 None)
                     dock_app.icon_filename = "STOCK_EXECUTE"
 
-        #TODO: can be removed when issue #144 is fixed
-        print ("da icon fn = %s %s" %(dock_app.icon_filename, self.box.get_scale_factor()))
-       
         if dock_app.icon_filename is None:
             # the default theme has no icon for the app, so there are a few
             # things we can do...
@@ -3208,17 +3203,19 @@ class Dock(object):
 
             icon_file = ""
             if os.path.isfile(dock_app.icon_name):
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file(dock_app.icon_name)
+                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(dock_app.icon_name,
+                                                                icon_size * scale_factor,
+                                                                icon_size * scale_factor)
             else:
                 icon_name = dock_app.icon_name
 
                 # look in the 'hicolor' icon directories for the icon file
-                icon_path = "/usr/share/icons/hicolor/%dx%d/apps/" % (icon_size, icon_size)
+                icon_path = "/usr/share/icons/hicolor/%dx%d/apps/" % (icon_size * scale_factor, icon_size * scale_factor)
                 if os.path.isfile("%s%s" % (icon_path, icon_name)):
                     icon_file = "%s%s" % (icon_path, icon_name)
                 else:
                     icon_path = os.path.expanduser("~/.local/share/icons/hicolor/%dx%d/apps/"
-                                                   % (icon_size, icon_size))
+                                                   % (icon_size * scale_factor, icon_size * scale_factor))
                     if os.path.isfile("%s%s" % (icon_path, icon_name)):
                         icon_file = "%s%s" % (icon_path, icon_name)
 
@@ -3238,11 +3235,11 @@ class Dock(object):
                     if os.path.isfile(os.path.expanduser("~/.local/share/icons/%s" % dock_app.icon_name)):
                         icon_file = os.path.expanduser("~/.local/share/icons/%s" % dock_app.icon_name)
 
-                #TODO: can be removed when issue #144 is fixed
-                print ("icon file = %s" %icon_file )
                 # if we've found an icon, load it
                 if icon_file != "":
-                        pixbuf = GdkPixbuf.Pixbuf.new_from_file(icon_file)
+                        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_file,
+                                                                        icon_size * scale_factor,
+                                                                        icon_size * scale_factor)
                 else:
                     # if not, use a stock icon to represent the app
                     pixbuf = self.applet.render_icon(Gtk.STOCK_EXECUTE,
@@ -3255,11 +3252,15 @@ class Dock(object):
         # scale the icon to the size that is available
         # Note - we're allowing for a 3 pixel border all around the icon,
         # hence using size-6
-        pixbuf = pixbuf.scale_simple(size - 6, size - 6,
+        pixbuf = pixbuf.scale_simple(scale_factor * (size - 6),
+                                     scale_factor * (size - 6),
                                      GdkPixbuf.InterpType.BILINEAR)
 
         dock_app.set_drawing_area_size(size)
         dock_app.set_pixbuf(pixbuf)
+
+        surface = Gdk.cairo_surface_create_from_pixbuf(pixbuf, scale_factor, None)
+        dock_app.set_surface(surface)
 
     def set_size_hints(self):
         """ Set the size hints for the applet

--- a/src/docked_app.in
+++ b/src/docked_app.in
@@ -329,6 +329,7 @@ class DockedApp(object):
         is_pulsing  : boolean - True if the app is pulsing
         pulse_step  : a count of how far we are through the pulse animation
         app_pb      : a pixbuf of the app's icon
+        app_surface : a surface of the app's icon
         highlight_colour : ColorTup of the colours used to highlight the app
                            when it is foreground
         is_active   : boolean - True = the app is the foreground app
@@ -403,6 +404,7 @@ class DockedApp(object):
         self.attention_blink_on = False
 
         self.app_pb = None
+        self.app_surface = None
 
         self.highlight_color = ColorTup(r=0.0, g=0.0, b=0.0)
 
@@ -946,7 +948,10 @@ class DockedApp(object):
             oss_w = self.drawing_area_size
             oss_h = self.drawing_area_size + ind_extra_s(self.indicator)
 
-        offscreen_surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, oss_w, oss_h)
+        offscreen_surface = cairo.Surface.create_similar(self.app_surface,
+                                                         cairo.CONTENT_COLOR_ALPHA,
+                                                         oss_w, oss_h)
+
         ctx = cairo.Context(offscreen_surface)
 
         if self.is_active and (self.is_dragee is False):
@@ -966,7 +971,7 @@ class DockedApp(object):
             dbgd.draw()
 
         # draw the app icon
-        Gdk.cairo_set_source_pixbuf(ctx, self.app_pb, 3, 3)
+        ctx.set_source_surface(self.app_surface, 3, 3)
 
         if self.is_pulsing:
             # draw the icon semi-transparently according to how far through the
@@ -1410,6 +1415,12 @@ class DockedApp(object):
 
         rht, ght, bht = self.highlight_color = get_avg_color(pixbuf)
         self.highlight_color = ColorTup(r=rht, g=ght, b=bht)
+
+    def set_surface(self, surface):
+        """Set the app surface
+        """
+
+        self.app_surface = surface
 
     def start_app(self):
         """Start the app or open a new window if it's already running


### PR DESCRIPTION
This change uses cairo surfaces instead of pixbufs to render icons compatible with HiDPI displays

Fixes #144